### PR TITLE
bugfix: normalize DFA transitions for missing alphabet symbols

### DIFF
--- a/src/components/DFAVisualizer.tsx
+++ b/src/components/DFAVisualizer.tsx
@@ -97,8 +97,20 @@ const DFAVisualizer = () => {
         const data = JSON.parse(content);
 
         if (data.alphabet && Array.isArray(data.states)) {
+          const newAlphabetArray = data.alphabet.split(',').map((c: string) => c.trim());
+          // Normalize transitions for all alphabet symbols
+          const normalizedStates = data.states.map((state: DFAState) => {
+            const transitions = Object.fromEntries(
+              newAlphabetArray.map((char: string) => [
+                char, 
+                state.transitions[char] || 'none' // Fill missing symbols with 'none'
+              ])
+            );
+            return { ...state, transitions };
+          });
+
           setAlphabet(data.alphabet);
-          setStates(data.states);
+          setStates(normalizedStates); // Use normalized states
           toast({
             title: "Import Successful",
             description: "Your DFA FSM has been imported successfully.",


### PR DESCRIPTION
This pull request includes an important update to the `DFAVisualizer` component in the `src/components/DFAVisualizer.tsx` file. The main change involves normalizing the transitions for all alphabet symbols when importing a DFA (Deterministic Finite Automaton) FSM (Finite State Machine).

Normalization of transitions:

* [`src/components/DFAVisualizer.tsx`](diffhunk://#diff-3897903cc72198a1a43af4c78cb20cd821f5378725f40dcb2963d5630986e489R100-R113): Added code to split the alphabet string into an array and trim each character. Then, for each state, the transitions are normalized by ensuring all alphabet symbols are present, filling any missing symbols with 'none'. This normalized state is then used to update the component's state.